### PR TITLE
Release v0.4.0 #minor

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -55,6 +55,13 @@ jobs:
         with:
           go-version: 1.16
       -
+        name: Docker Login
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
+      -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -63,12 +70,21 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Clear
+        if: always()
+        run: |
+          rm -f ${HOME}/.docker/config.json
   release:
     runs-on: ubuntu-latest
     needs: ["goreleaser", "create-tag"]
     name: Release Notification
     steps:
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
       - run: |
           echo "{\"text\":\"Vultr-CSI : Release https://github.com/${{ github.repository }}/releases/tag/${{ needs.create-tag.outputs.new_tag }} \"}" > mattermost.json
       - uses: mattermost/action-mattermost-notify@master

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,24 @@ before:
     - go mod download
     - go generate ./...
 builds:
- - skip: true
+  -
+    env:
+      - CGO_ENABLED=0
+
+    binary: csi-vultr-plugin
+    
+    flags:
+      - -trimpath #removes all file system paths from the compiled executable
+
+    goos:
+      - linux
+      - windows
+      - darwin
+
+    goarch:
+      - amd64
+      - arm64
+
 
 checksum:
   name_template: "{{ .ProjectName }}_v{{ .Version }}_checksums.txt"
@@ -18,6 +35,12 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+
+dockers:
+  - dockerfile: Dockerfile
+    image_templates:
+      - "vultr/vultr-csi:release"
+      - "vultr/vultr-csi:{{ .Tag }}"
 
 release:
   github:

--- a/docs/releases/latest.yml
+++ b/docs/releases/latest.yml
@@ -237,7 +237,7 @@ spec:
             - name: registration-dir
               mountPath: /registration/
         - name: csi-vultr-plugin
-          image: vultr/vultr-csi:v0.3.0
+          image: vultr/vultr-csi:v0.4.0
           args:
             - "--endpoint=$(CSI_ENDPOINT)"
           env:

--- a/docs/releases/v0.4.0.yml
+++ b/docs/releases/v0.4.0.yml
@@ -237,7 +237,7 @@ spec:
             - name: registration-dir
               mountPath: /registration/
         - name: csi-vultr-plugin
-          image: vultr/vultr-csi:v0.3.0
+          image: vultr/vultr-csi:v0.4.0
           args:
             - "--endpoint=$(CSI_ENDPOINT)"
           env:


### PR DESCRIPTION
## [v0.4.0](https://github.com/vultr/vultr-csi) (2022-01-19)
### Enhancements
* Update CSIDriver Kind to use API v1 1.22 support [52](https://github.com/vultr/vultr-csi/pull/52)