### PR TITLE
Release v0.4.0 #minor

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,9 +1,6 @@
 name: "Unit/Coverage Tests" 
 
 on:
-  push:
-    branches:
-      - master
   pull_request_target:
     branches:
       - master

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,6 +4,8 @@ before:
     - go generate ./...
 builds:
   -
+    main: ./cmd/csi-vultr-driver/
+    
     env:
       - CGO_ENABLED=0
 
@@ -14,7 +16,6 @@ builds:
 
     goos:
       - linux
-      - windows
       - darwin
 
     goarch:


### PR DESCRIPTION
## [v0.4.0](https://github.com/vultr/vultr-csi) (2022-01-19)
### Enhancements
* Update CSIDriver Kind to use API v1 1.22 support [52](https://github.com/vultr/vultr-csi/pull/52)