### PR TITLE
fix typo in csi_plugin.id in csi-node.nomad.hcl

### DIFF
--- a/docs/nomad/examples/csi-node.nomad.hcl
+++ b/docs/nomad/examples/csi-node.nomad.hcl
@@ -18,7 +18,7 @@ job "vultr-csi-nodes" {
       }
 
       csi_plugin {
-        id        = "vultr-amd"
+        id        = "vultr-ams"
         type      = "node"
         mount_dir = "/csi"
       }


### PR DESCRIPTION
fix typo "vultr-amd" -> "vultr-ams"

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Found a typo which can confuse someone. Tested that version with `id = "vultr-amd"` not work and `id = "vultr-ams"` works.

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
