### PR TITLE
Resolve build errors from statfs type inconsistencies in darwin arm64

### DIFF
--- a/driver/mounter.go
+++ b/driver/mounter.go
@@ -268,9 +268,10 @@ func (m *mounter) GetStatistics(target string) (volumeStatistics, error) {
 	}
 
 	volStats := volumeStatistics{
-		availableBytes: int64(statfs.Bavail) * statfs.Bsize,
-		totalBytes:     int64(statfs.Blocks) * statfs.Bsize,
-		usedBytes:      (int64(statfs.Blocks) - int64(statfs.Bfree)) * statfs.Bsize,
+		// darwin arm64 on statfs.Bsize returns uint32 so we explicitly cast to int64
+		availableBytes: int64(statfs.Bavail) * int64(statfs.Bsize),                         //nolint: unconvert
+		totalBytes:     int64(statfs.Blocks) * int64(statfs.Bsize),                         //nolint: unconvert
+		usedBytes:      (int64(statfs.Blocks) - int64(statfs.Bfree)) * int64(statfs.Bsize), //nolint: unconvert
 
 		availableInodes: int64(statfs.Ffree),
 		totalInodes:     int64(statfs.Files),


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
The goreleaser build failing on darwin arm64 due to mismatched types
```
    • building                                       binary=dist/vultr-csi_darwin_amd64_v1/csi-vultr-plugin
    • took: 14s
  ⨯ release failed after 25s                 error=failed to build for darwin_arm64: exit status 1: # github.com/vultr/vultr-csi/driver
driver/mounter.go:271:19: invalid operation: int64(statfs.Bavail) * statfs.Bsize (mismatched types int64 and uint32)
driver/mounter.go:272:19: invalid operation: int64(statfs.Blocks) * statfs.Bsize (mismatched types int64 and uint32)
driver/mounter.go:273:19: invalid operation: (int64(statfs.Blocks) - int64(statfs.Bfree)) * statfs.Bsize (mismatched types int64 and uint32)
```

The fix is to explicitly cast the type, even though it's redundant for the other builds and the linter will squawk.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
