### PR TITLE
Decrease node maximum mount limit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+.PHONY: clean
+clean: 
+	rm -rf dist/ csi-vultr-plugin
+
 .PHONY: deploy
 deploy: build-linux docker-build docker-push
 

--- a/driver/node.go
+++ b/driver/node.go
@@ -15,7 +15,7 @@ const (
 	diskPath   = "/dev/disk/by-id"
 	diskPrefix = "virtio-"
 
-	maxVolumesPerNode = 16
+	maxVolumesPerNode = 11
 
 	volumeModeBlock      = "block"
 	volumeModeFilesystem = "filesystem"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Due to newly discovered VM limitations, we need to lower the volume mount limit for all nodes.

Additionally, adds a clean action to the Makefile

## Testing
```
kubectl replace -f csi-decrease-node-limit.yaml # replace the CSI
kubectl set image daemonset csi-vultr-node --namespace kube-system csi-vultr-plugin=IMAGE_REPO/vultr-csi:decrease-node-limit # update the image changes
kubectl rollout status daemonset csi-vultr-node --namespace kube-system # monitor image changes
kubectl describe csinodes.storage.k8s.io # Check the allocatables which should show 11
```

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
