### PR TITLE
Add support for Docker Swarm

### DIFF
--- a/deploy/docker-swarm/Dockerfile
+++ b/deploy/docker-swarm/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.21-alpine as builder
+ARG VERSION=0.0.0-dev
+
+WORKDIR /go/src/github.com/vultr/vultr-csi
+COPY --from=src . /go/src/github.com/vultr/vultr-csi
+RUN CGO_ENABLED=0 go build -ldflags "-X main.version=${VERSION}" -o csi-vultr-plugin ./cmd/csi-vultr-driver
+
+FROM alpine:3.18
+
+RUN apk add --no-cache ca-certificates e2fsprogs findmnt bind-tools e2fsprogs-extra xfsprogs xfsprogs-extra blkid
+
+COPY --from=builder /go/src/github.com/vultr/vultr-csi/csi-vultr-plugin /
+COPY entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]

--- a/deploy/docker-swarm/Makefile
+++ b/deploy/docker-swarm/Makefile
@@ -1,0 +1,34 @@
+PLUGIN_NAME = vultr/vultr-csi
+PLUGIN_TAG = latest
+PLUGIN_ARCH = amd64
+
+all: clean rootfs create
+
+clean:
+	@echo "### rm ./plugin"
+	@rm -rf ./plugin
+
+rootfs:
+	@echo "### docker build: rootfs image with ${PLUGIN_NAME}"
+	@docker build --build-context src=../../ --platform linux/${PLUGIN_ARCH} -t ${PLUGIN_NAME}:rootfs .
+	@echo "### create rootfs directory in ./plugin/rootfs"
+	@mkdir -p ./plugin/rootfs
+	@docker create --name tmp ${PLUGIN_NAME}:rootfs
+	@docker export tmp | tar -x -C ./plugin/rootfs
+	@echo "### copy config.json to ./plugin/"
+	@cp config.json ./plugin/
+	@docker rm -vf tmp
+
+create:
+	@echo "### remove existing plugin ${PLUGIN_NAME}:${PLUGIN_TAG} if exists"
+	@docker plugin rm -f ${PLUGIN_NAME}:${PLUGIN_TAG} || true
+	@echo "### create new plugin ${PLUGIN_NAME}:${PLUGIN_TAG} from ./plugin"
+	@docker plugin create ${PLUGIN_NAME}:${PLUGIN_TAG} ./plugin
+
+enable:
+	@echo "### enable plugin ${PLUGIN_NAME}:${PLUGIN_TAG}"
+	@docker plugin enable ${PLUGIN_NAME}:${PLUGIN_TAG}
+
+push: clean rootfs create enable
+	@echo "### push plugin ${PLUGIN_NAME}:${PLUGIN_TAG}"
+	@docker plugin push ${PLUGIN_NAME}:${PLUGIN_TAG}

--- a/deploy/docker-swarm/config.json
+++ b/deploy/docker-swarm/config.json
@@ -1,0 +1,50 @@
+{
+  "description": "Vultr csi plugin for Docker",
+  "documentation": "https://github.com/moby/moby/blob/master/docs/cluster_volumes.md",
+  "entrypoint": [
+    "/entrypoint.sh"
+  ],
+  "env": [
+    {
+      "name": "VULTR_API_URL",
+      "settable": [
+        "value"
+      ],
+      "value": ""
+    },
+    {
+      "name": "VULTR_API_TOKEN",
+      "settable": [
+        "value"
+      ],
+      "value": ""
+    }
+  ],
+  "interface": {
+    "socket": "csi-vultr.sock",
+    "types": [
+      "docker.csicontroller/1.0",
+      "docker.csinode/1.0"
+    ]
+  },
+  "linux": {
+    "allowAllDevices": true,
+    "capabilities": [
+      "CAP_SYS_ADMIN"
+    ]
+  },
+  "mounts": [
+    {
+      "destination": "/dev",
+      "options": [
+        "rbind"
+      ],
+      "source": "/dev",
+      "type": "bind"
+    }
+  ],
+  "network": {
+    "type": "host"
+  },
+  "propagatedMount": "/data/published"
+}

--- a/deploy/docker-swarm/entrypoint.sh
+++ b/deploy/docker-swarm/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+exec /csi-vultr-plugin \
+	-endpoint "unix:///run/docker/plugins/csi-vultr.sock" \
+	-api-url "${VULTR_API_URL}" \
+	-token "${VULTR_API_TOKEN}"


### PR DESCRIPTION
## Description
This PR adds support for Docker Swarm. The CSI plugin could also be pushed in a Github workflow to the tag `vultr/vultr-csi`.

## Related Issues
Fixes #179.
