### PR TITLE
Set default block storage type during NodeStageVolume

### DIFF
--- a/driver/controller.go
+++ b/driver/controller.go
@@ -297,7 +297,7 @@ func (c *VultrControllerServer) ControllerPublishVolume(ctx context.Context, req
 			return nil, status.Errorf(codes.Aborted, "cannot attach volume to node: %v", err.Error())
 		}
 
-		return nil, status.Errorf(codes.Internal, "ControllPublishVolume: cannot attach volume to node: %v", err.Error())
+		return nil, status.Errorf(codes.Internal, "ControllerPublishVolume: cannot attach volume to node: %v", err.Error())
 	}
 
 	attachReady := false

--- a/driver/node.go
+++ b/driver/node.go
@@ -249,7 +249,7 @@ func (n *VultrNodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.Node
 		return nil, err
 	}
 
-	n.Driver.log.Info("NodePublishVolume: unpublished")
+	n.Driver.log.Info("NodeUnpublishVolume: unpublished")
 	return &csi.NodeUnpublishVolumeResponse{}, nil
 }
 

--- a/driver/node.go
+++ b/driver/node.go
@@ -64,6 +64,14 @@ func (n *VultrNodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStag
 	mountVolName := publishContext["mount_vol_name"]
 	storageType := publishContext["storage_type"]
 
+	// A workaround default storage type of 'block'
+	// Attach only gets new publish context when the volume is not already
+	// attached to the node. That should only happen to existing block storage
+	// volumes
+	if storageType == "" {
+		storageType = "block"
+	}
+
 	source := ""
 	target := req.StagingTargetPath
 	mountBlk := req.VolumeCapability.GetMount()


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Older versions of the CSI storage classes don't include the `storage_type` param.  The CSI controller already handles the missing param and it should be present in the publish context when the CSI tries to publish a brand new volume.  However, if the volume is already attached, the controller doesn't interact with the extant node volume and simply starts polling the volume ([design doc source](https://github.com/kubernetes/design-proposals-archive/blob/main/storage/container-storage-interface.md#attaching-and-detaching-1))

Older block storages need to be able to mount/re-mount these volumes so the current behavior is broken for existing nodes.  This workaround assumes that the storage is block unless otherwise specified.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
