### PR TITLE
Check mount and device during node staging/attach

### DIFF
--- a/driver/node.go
+++ b/driver/node.go
@@ -41,7 +41,7 @@ func NewVultrNodeDriver(driver *VultrDriver) *VultrNodeServer {
 
 // NodeStageVolume perpares the node for the new volume to be mounted. This is
 // executed after the ControllerPublishVolume and before the NodePublishVolume.
-func (n *VultrNodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+func (n *VultrNodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) { //nolint:gocyclo,lll
 	if req.VolumeId == "" {
 		return nil, status.Error(codes.InvalidArgument, "NodeStageVolume: Volume ID must be provided")
 	}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Adds logic to the node process which will check if the specified device and path is currently mounted.  If so, reply OK.  This is required by CSI specification as it expects all driver calls to be idempotent.

Not checking for this before mounted tended to cause errors when trying to re-mount the device after migrating pods or nodes.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
